### PR TITLE
Make badges section a paragraph that pkgdown can recognize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # The `git2rdata` package <img src="man/figures/logo.png" align="right" alt="" width="120" />
 
+
+<!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/git2rdata)](https://cran.r-project.org/package=git2rdata)
 [![Rdoc](https://www.rdocumentation.org/badges/version/git2rdata)](https://www.rdocumentation.org/packages/git2rdata)
-
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![lifecycle](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/#maturing)
 [![](https://badges.ropensci.org/263_status.svg)](https://github.com/ropensci/software-review/issues/263)
-
 [![Licence](https://img.shields.io/badge/licence-GPL--3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 [![minimal R version](https://img.shields.io/badge/R%3E%3D-3.5.0-6666ff.svg)](https://cran.r-project.org/)
 [![DOI](https://zenodo.org/badge/147685405.svg)](https://zenodo.org/badge/latestdoi/147685405)
-
 [![Travis-CI Build Status](https://travis-ci.org/ropensci/git2rdata.svg?branch=master)](https://travis-ci.org/ropensci/git2rdata)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/cfbjb835fqb3dc7m/branch/master?svg=true)](https://ci.appveyor.com/project/ThierryO/git2rdata-n60yg/branch/master)
 [![codecov](https://codecov.io/gh/ropensci/git2rdata/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/git2rdata)
-
 ![GitHub forks](https://img.shields.io/github/forks/ropensci/git2rdata.svg?style=social)
 ![GitHub stars](https://img.shields.io/github/stars/ropensci/git2rdata.svg?style=social)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/ropensci/git2rdata.svg)
 ![GitHub repo size](https://img.shields.io/github/repo-size/ropensci/git2rdata.svg)
+<!-- badges: end -->
 
 <p style="display:none">Please visit the git2rdata website at https://ropensci.github.io/git2rdata/. The vignette code on the website link to a rendered version of the vignette. Functions have a link to their help file.</p>
 


### PR DESCRIPTION
For pkgdown to recognize the badges paragraph and put it in the sidebar as "Dev status" (see e.g. https://docs.ropensci.org/ropenaq/) it needs to be a paragraph, and to be even more certain it'll be recognized I've added the badges paragraph limits that pkgdown uses when the badges paragraph isn't the first paragraph (although here it's the first paragraph).

But maybe you don't want that sidebar thing. :-)