### PR TITLE
Fix link to broken logo + shorten title to package title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git2rdata <img src="man/figures/logo.svg" align="right" alt="git2rdata logo" width="120" />
+# git2rdata <img src="man/figures/logo.svg" align="right" alt="git2rdata logo" width="120">
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/git2rdata)](https://cran.r-project.org/package=git2rdata)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The `git2rdata` package <img src="https://ropensci.github.io/git2rdata/docs/reference/figures/logo.svg" align="right" alt="gitr2data logo" width="120" />
+# git2rdata <img src="man/figures/logo.svg" align="right" alt="git2rdata logo" width="120" />
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/git2rdata)](https://cran.r-project.org/package=git2rdata)


### PR DESCRIPTION
## Description

- Use relative link for logo: should work on GitHub and pkgdown website
- Use `git2rdata` as title
- Fix typo in `alt`

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
